### PR TITLE
fix cm broken due to comment and script

### DIFF
--- a/hetzner-failover/templates/configmap-ip.yaml
+++ b/hetzner-failover/templates/configmap-ip.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: vip-configmap
 data:
-{{ .Values.floatingip1 | indent 2 -}}: {{ .Release.Namespace -}}/{{- .Values.target -}} # add your config map here. must map the base64 encoded IP in secrets.yaml
+{{ .Values.floatingip1 | indent 2 -}}: {{ .Release.Namespace -}}/{{- .Values.target -}}

--- a/hetzner-failover/templates/configmap-script.yaml
+++ b/hetzner-failover/templates/configmap-script.yaml
@@ -11,10 +11,8 @@ data:
     TYPE=$1
     if [ "$ENDSTATE" == "MASTER" ] ; then
         HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7 }')
-        export SERVER_ID=$(curl -H "Authorization: Bearer $HETZNER_TOKEN" "https://api.hetzner.cloud/v1/servers?name=$HOSTNAME" |python3 -c "import sys, json; print(json.load(sys.stdin)['servers'][0]['id'])")
-        export FLOATING_IP_ID=$(curl -H "Authorization: Bearer $HETZNER_TOKEN" "https://api.hetzner.cloud/v1/floating_ips" |python3 -c "import json,sys;fips=json.load(sys.stdin)['floating_ips'];[print(ip['id']) for ip in fips if ip['description'] == 'fip1.global-nights.com']")
-        export FLOATING_IP=$(curl -H "Authorization: Bearer $HETZNER_TOKEN" "https://api.hetzner.cloud/v1/floating_ips" |python3 -c "import json,sys;fips=json.load(sys.stdin)['floating_ips'];[print(ip['ip']) for ip in fips if ip['description'] == 'fip1.global-nights.com']")
+        export SERVER_ID=$(curl -s -H "Authorization: Bearer $HETZNER_TOKEN" "https://api.hetzner.cloud/v1/servers?name=$HOSTNAME" | grep -C 2 servers | grep id | awk '{ print $2 }' | sed -e s/,//)
+        export FLOATING_IP_ID=$(curl -s -H "Authorization: Bearer $HETZNER_TOKEN" "https://api.hetzner.cloud/v1/floating_ips" | grep "\"ip\": \"$FLOATING_IP" -B 3  | grep id | awk '{ print $2 }' | sed -e s/,//)
         curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $HETZNER_TOKEN" -d "{\"server\":$SERVER_ID}" "https://api.hetzner.cloud/v1/floating_ips/$FLOATING_IP_ID/actions/assign"
-        ip addr add $FLOATING_IP/32 dev eth0 || echo "IP was already added to the interface"
         echo "setting Failover IP:  $FLOATING_IP to Server IP:  $HOST_IP"
     fi

--- a/hetzner-failover/values.yaml
+++ b/hetzner-failover/values.yaml
@@ -3,9 +3,7 @@
 # Declare variables to be passed into your templates.
 rbac: true
 failoverip1: place-your-failover-ip-here
-hetzneruser: place-your-email-here
 hetznertoken: place-your-token-here
-hetznerpass: place-your-password-here
 namespace: default
 target: nginx
 replicaCount: 1


### PR DESCRIPTION
Hi @exocode,
The config map was not working / templated correctly due to the comment in the end. I fixed that.
Also the image for now contains no python3 :( and I don't know if I should add because I would like to do a pr to the k8s/contrib repo where it originates from and I don't know if they accept if the image gets too big.

So for now I did some nasty sh scripting ... but for me it works now.
I removed username / password from the values becasue they were only necessary for bare metal. Maybe I will send an other pr to use optionally the cloud / or the bare metal api later.

I also changed the script to not do an ifconfig, because keepalived will configure the ip for your if it is master.

I was also experimentig with adding the stable/nginx-ingress chart as a requirement but did not include this in the pr. What do you think about it?

Another flaw is that for now it only works in the default namespace, due to rbac templates. Maybe this can change in the future to support a different namespace like `ingress` for example.



 