### PR TITLE
Add VRID to template to support multiple keepalived instances

### DIFF
--- a/hetzner-failover-ip/README.md
+++ b/hetzner-failover-ip/README.md
@@ -79,7 +79,7 @@ helm install hetzner-failover-ip --name hetzner-failover-ip \
 
 #### Example NodeSelector with multiple IPs and `nginx-ingress`
 
-Install `nginx-ingress` with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual Hetzner floating IPs.`nginx-ingress` will be started on every k8s node.
+Install `nginx-ingress` with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual Hetzner floating IPs.`nginx-ingress` will be started on every k8s `node`.
 ```
 helm install stable/nginx-ingress --name ingress --namespace ingress \
 --set rbac.create=true \
@@ -90,7 +90,7 @@ helm install stable/nginx-ingress --name ingress --namespace ingress \
 --set controller.metrics.enabled=true
 ```
 
-Install 2 keepalived with these IPs(one install per IP) and different namespace and VRID, bind it to `nginx-ingress` and nodes with label `role=worker` only
+Install 2 `keepalived` with these IPs(one install per IP) and different namespace and VRID, bind it to `nginx-ingress` and `nodes` with label `role=worker` only
 ```
 helm install hetzner-failover-ip --name floating-ip0 --namespace floating-ip0 \
 --set floatingip1=1.2.3.4 \
@@ -114,7 +114,7 @@ helm install hetzner-failover-ip --name floating-ip1 --namespace floating-ip1 \
 --set nodeSelectorValue=worker \
 --set replicaCount=2
 ```
-Label all non-master nodes as workers to keepalived
+Label all non-master `nodes` as workers to `keepalived`
 ```
 kubectl get nodes -o name -l '!node-role.kubernetes.io/master,!role'|xargs -n1 -I'{}' kubectl label '{}' role=worker
 ```

--- a/hetzner-failover-ip/README.md
+++ b/hetzner-failover-ip/README.md
@@ -82,36 +82,36 @@ helm install hetzner-failover-ip --name hetzner-failover-ip \
 Install `nginx-ingress` with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual Hetzner floating IPs.`nginx-ingress` will be started on every k8s node.
 ```
 helm install stable/nginx-ingress --name ingress --namespace ingress \
---set rbac.create=true,\
---set controller.kind=DaemonSet,\
---set controller.service.type=ClusterIP,\
---set controller.service.externalIPs='{1.2.3.4,5.6.7.8}',\
---set controller.stats.enabled=true,\
+--set rbac.create=true \
+--set controller.kind=DaemonSet \
+--set controller.service.type=ClusterIP \
+--set controller.service.externalIPs='{1.2.3.4,5.6.7.8}' \
+--set controller.stats.enabled=true \
 --set controller.metrics.enabled=true
 ```
 
 Install 2 keepalived with these IPs(one install per IP) and different namespace and VRID, bind it to `nginx-ingress` and nodes with label `role=worker` only
 ```
 helm install hetzner-failover-ip --name floating-ip0 --namespace floating-ip0 \
---set floatingip1=1.2.3.4,\
---set vrid=50,\
---set hetznertoken=API_TOKEN,\
---set namespace=ingress,\
---set target=ingress-nginx-ingress-controller,\
---set serviceType=node,\
---set nodeSelectorKey=role,\
---set nodeSelectorValue=worker,\
+--set floatingip1=1.2.3.4 \
+--set vrid=50 \
+--set hetznertoken=API_TOKEN \
+--set namespace=ingress \
+--set target=ingress-nginx-ingress-controller \
+--set serviceType=node \
+--set nodeSelectorKey=role \
+--set nodeSelectorValue=worker \
 --set replicaCount=2
 
 helm install hetzner-failover-ip --name floating-ip1 --namespace floating-ip1 \
---set floatingip1=5.6.7.8,\
---set vrid=51,\
---set hetznertoken=API_TOKEN,\
---set namespace=ingress,\
---set target=ingress-nginx-ingress-controller,\
---set serviceType=node,\
---set nodeSelectorKey=role,\
---set nodeSelectorValue=worker,\
+--set floatingip1=5.6.7.8 \
+--set vrid=51 \
+--set hetznertoken=API_TOKEN \
+--set namespace=ingress \
+--set target=ingress-nginx-ingress-controller \
+--set serviceType=node \
+--set nodeSelectorKey=role \
+--set nodeSelectorValue=worker \
 --set replicaCount=2
 ```
 Label all non-master nodes as workers to keepalived

--- a/hetzner-failover-ip/README.md
+++ b/hetzner-failover-ip/README.md
@@ -79,11 +79,16 @@ helm install hetzner-failover-ip --name hetzner-failover-ip \
 
 #### Example NodeSelector with multiple IPs and `nginx-ingress`
 
-Install `nginx-ingress` with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual Hetzner floating IPs
+Install `nginx-ingress` with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual Hetzner floating IPs.`nginx-ingress` will be started on every k8s node.
 ```
-helm install stable/nginx-ingress --name ingress --namespace ingress --set rbac.create=true,controller.kind=DaemonSet,controller.service.type=ClusterIP,controller.service.externalIPs='{1.2.3.4,5.6.7.8}',controller.stats.enabled=true,controller.metrics.enabled=true
+helm install stable/nginx-ingress --name ingress --namespace ingress \
+--set rbac.create=true,\
+--set controller.kind=DaemonSet,\
+--set controller.service.type=ClusterIP,\
+--set controller.service.externalIPs='{1.2.3.4,5.6.7.8}',\
+--set controller.stats.enabled=true,\
+--set controller.metrics.enabled=true
 ```
-`nginx-ingress` will be started on every k8s node
 
 Install 2 keepalived with these IPs(one install per IP) and different namespace and VRID, bind it to `nginx-ingress` and nodes with label `role=worker` only
 ```
@@ -97,6 +102,7 @@ helm install hetzner-failover-ip --name floating-ip0 --namespace floating-ip0 \
 --set nodeSelectorKey=role,\
 --set nodeSelectorValue=worker,\
 --set replicaCount=2
+
 helm install hetzner-failover-ip --name floating-ip1 --namespace floating-ip1 \
 --set floatingip1=5.6.7.8,\
 --set vrid=51,\

--- a/hetzner-failover-ip/templates/rbac.yaml
+++ b/hetzner-failover-ip/templates/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-keepalived-vip
+  name: kube-keepalived-vip-{{ .Values.floatingip1 }}
 rules:
 - apiGroups: [""]
   resources:
@@ -22,13 +22,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-keepalived-vip
+  name: kube-keepalived-vip-{{ .Values.floatingip1 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-keepalived-vip
+  name: kube-keepalived-vip-{{ .Values.floatingip1 }}
 subjects:
 - kind: ServiceAccount
   name: kube-keepalived-vip
-  namespace: default
+  namespace: {{ default "default" .Release.Namespace }}
 {{- end -}}

--- a/hetzner-failover-ip/templates/replicaset.yaml
+++ b/hetzner-failover-ip/templates/replicaset.yaml
@@ -89,6 +89,7 @@ spec:
         - --services-configmap={{ default "default" .Release.Namespace }}/vip-configmap
         - --watch-all-namespaces=true
         - --use-unicast=true
+        - --vrid={{ default "50" .Values.vrid }}
         # unicast uses the ip of the nodes instead of multicast
         # this is useful if running in cloud providers (like AWS)
         #- --use-unicast=true


### PR DESCRIPTION
This PR allows to use multiple keepalived instances (in separate namespaces) in one k8s system to use multiple floating IPs as a work-around while multiple IPs aren't supported inside single kube-keepalived deploy. Here is an example with nginx-ingress
```
#install nginx-ingress with 2 IPs 1.2.3.4,5.6.7.8, replace with your actual IPs
helm install stable/nginx-ingress --name ingress --namespace ingress --set rbac.create=true,controller.kind=DaemonSet,controller.service.type=ClusterIP,controller.service.externalIPs='{1.2.3.4,5.6.7.8}',controller.stats.enabled=true,controller.metrics.enabled=true
#install 2 keepalived with these IPs(one install per IP) and different namespace and VRID
helm install hetzner-failover-ip --name floating-ip0 --namespace floating-ip0 --set floatingip1=1.2.3.4,vrid=50,hetznertoken=API_TOKEN,namespace=ingress,target=ingress-nginx-ingress-controller,serviceType=node,nodeSelectorKey=role,nodeSelectorValue=worker,replicaCount=2
helm install hetzner-failover-ip --name floating-ip1 --namespace floating-ip1 --set floatingip1=5.6.7.8,vrid=51,hetznertoken=API_TOKEN,namespace=ingress,target=ingress-nginx-ingress-controller,serviceType=node,nodeSelectorKey=role,nodeSelectorValue=worker,replicaCount=2
```